### PR TITLE
V113 improvements, second round

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 *.sw[op]
 *.pyc
 .DS_Store
+*.log

--- a/R Integration.pyt
+++ b/R Integration.pyt
@@ -115,9 +115,9 @@ class RInstallDetails(object):
             current_package_path = rtools.rpath.r_pkg_path()
             current_package_version = rtools.rpath.r_pkg_version()
             if current_package_path is None or current_package_version is None:
-                arcpy.AddWarning(dedent("""\
-                    The ArcGIS R package is not installed. Use the 'Install
-                    R Bindings' tool to install them."""))
+                arcpy.AddWarning("The ArcGIS R package is not installed."
+                                 " Use the 'Install R Bindings' tool to "
+                                 "install them.")
             else:
                 arcpy.AddMessage(
                     "The ArcGIS R package (version {}) is installed at: {}".format(


### PR DESCRIPTION
Clarify installation with admin, typo fix
 - When installing into ArcGIS 10.3.1, if the user doesn't have write permission to their ArcGIS installation directory, flag it immediately instead of crashing in the middle of the process and notify them of how to avoid the issue.
 - Fix wrapping on R installation details script.