### PR TITLE
Network install

### DIFF
--- a/rtools/bootstrap_r.py
+++ b/rtools/bootstrap_r.py
@@ -65,9 +65,7 @@ def execute_r(command='Rcmd', *args):
                     # highlight standard error as warnings
                     arcpy.AddWarning(stderr_msg)
 
-            if process.returncode == 0:
-                pass
-            else:
+            if process.returncode != 0:
                 arcpy.AddWarning("R command returned non-zero exit status.")
             return process.returncode
 

--- a/rtools/install_package.py
+++ b/rtools/install_package.py
@@ -25,6 +25,7 @@ except ImportError:
 from .bootstrap_r import execute_r
 from .github_release import save_url, release_info
 from .rpath import (
+    r_install_path,
     r_library_path,
     r_pkg_path,
     r_pkg_version,
@@ -211,6 +212,14 @@ def install_package(overwrite=False, r_library_path=r_library_path):
         local_install = False
         zip_name = os.path.basename(download_url)
 
+    # check for a network-based R installation
+    if r_install_path[0:2] == r'\\':
+        arcpy.AddMessage(
+            "R installed on a network path, using fallback installation method.")
+        r_local_install = False
+    else:
+        r_local_install = True
+
     # we have a release, write it to disk for installation
     with mkdtemp() as temp_dir:
         package_path = os.path.join(temp_dir, zip_name)
@@ -222,7 +231,19 @@ def install_package(overwrite=False, r_library_path=r_library_path):
         if os.path.exists(package_path):
             # TODO -- need to do UAC escalation here?
             # call the R installation script
-            execute_r('Rcmd', 'INSTALL', package_path)
+            rcmd_return = 0
+            if r_local_install:
+                rcmd_return = execute_r('Rcmd', 'INSTALL', package_path)
+            if not r_local_install or rcmd_return != 0:
+                # Can't execute Rcmd in this context, write out a temporary
+                # script and run install.packages() from within an R session.
+                install_script = os.path.join(temp_dir, 'install.R')
+                with open(install_script, 'w') as f:
+                    f.write("install.packages(\"{}\", repos=NULL)".format(
+                        package_path.replace("\\", "/")))
+                rcmd_return = execute_r("Rscript", install_script)
+                if rcmd_return != 0:
+                    arcpy.AddWarning("Fallback installation method failed.")
         else:
             arcpy.AddError("No package found at {}".format(package_path))
             return


### PR DESCRIPTION
If the R installation is located on a network resource, then `Rcmd` will fail. Fall back to executing an `install.packages()` operation.